### PR TITLE
Display full path to job including any folder names

### DIFF
--- a/src/main/resources/com/robestone/hudson/compactcolumns/JobNameColorColumn/column.jelly
+++ b/src/main/resources/com/robestone/hudson/compactcolumns/JobNameColorColumn/column.jelly
@@ -3,6 +3,6 @@
         <a href="${jobBaseUrl}${job.shortUrl}"
         	tooltip="${it.getToolTip(job, request.locale)}"
         	style="${it.getStyle(job)}"
-         >${job.displayName}</a>
+         >${job.getRelativeDisplayNameFrom(currentView.owner.itemGroup)}</a>
     </td>
 </j:jelly>

--- a/src/main/resources/com/robestone/hudson/compactcolumns/JobNameColumn/column.jelly
+++ b/src/main/resources/com/robestone/hudson/compactcolumns/JobNameColumn/column.jelly
@@ -2,6 +2,6 @@
     <td style="${indenter.getCss(job)}">
         <a href="${jobBaseUrl}${job.shortUrl}"
         	tooltip="${job.description}"
-         >${job.displayName}</a>
+         >${job.getRelativeDisplayNameFrom(currentView.owner.itemGroup)}</a>
     </td>
 </j:jelly>


### PR DESCRIPTION
We wanted to use the job name column to get the hover description, but needed support for folders.
