### PR TITLE
Better "symbolic" names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,21 @@
     <doclint>all</doclint>
   </properties>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci</groupId>
+      <artifactId>symbol-annotation</artifactId>
+      <version>1.13</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>job-dsl</artifactId>
+      <version>1.72</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>

--- a/src/main/java/com/robestone/hudson/compactcolumns/AllStatusesColumn.java
+++ b/src/main/java/com/robestone/hudson/compactcolumns/AllStatusesColumn.java
@@ -24,6 +24,7 @@
 package com.robestone.hudson.compactcolumns;
 
 import hudson.Extension;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /** @author jacob robertson */
@@ -59,7 +60,8 @@ public class AllStatusesColumn extends AbstractStatusesColumn {
   }
 
   @Extension
-  public static class AllStatusesColumnDescriptor extends AbstractCompactColumnDescriptor {
+  @Symbol("compactAllStatuses")
+  public static class DescriptorImpl extends AbstractCompactColumnDescriptor {
     @Override
     public String getDisplayName() {
       return Messages.Compact_Column_Statuses_w_Options();

--- a/src/main/java/com/robestone/hudson/compactcolumns/JobNameColorColumn.java
+++ b/src/main/java/com/robestone/hudson/compactcolumns/JobNameColorColumn.java
@@ -9,6 +9,7 @@ import hudson.model.Run;
 import java.util.List;
 import java.util.Locale;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /** @author jacob robertson */
@@ -119,6 +120,7 @@ public class JobNameColorColumn extends AbstractCompactColumn {
   }
 
   @Extension
+  @Symbol("compactJobNameColor")
   public static class DescriptorImpl extends AbstractCompactColumnDescriptor {
     public String getColumnDisplayName() {
       return hudson.views.Messages.JobColumn_DisplayName();

--- a/src/main/java/com/robestone/hudson/compactcolumns/JobNameColumn.java
+++ b/src/main/java/com/robestone/hudson/compactcolumns/JobNameColumn.java
@@ -3,6 +3,7 @@ package com.robestone.hudson.compactcolumns;
 import com.robestone.hudson.compactcolumns.AbstractStatusesColumn.AbstractCompactColumnDescriptor;
 import hudson.Extension;
 import hudson.views.JobColumn;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /** @author jacob robertson */
@@ -12,6 +13,7 @@ public class JobNameColumn extends JobColumn {
   public JobNameColumn() {}
 
   @Extension
+  @Symbol("compactJobName")
   public static class DescriptorImpl extends AbstractCompactColumnDescriptor {
     public String getColumnDisplayName() {
       return hudson.views.Messages.JobColumn_DisplayName();

--- a/src/main/java/com/robestone/hudson/compactcolumns/LastStableAndUnstableColumn.java
+++ b/src/main/java/com/robestone/hudson/compactcolumns/LastStableAndUnstableColumn.java
@@ -24,6 +24,7 @@
 package com.robestone.hudson.compactcolumns;
 
 import hudson.Extension;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /** @author jacob robertson */
@@ -44,8 +45,8 @@ public class LastStableAndUnstableColumn extends AbstractStatusesColumn {
   }
 
   @Extension
-  public static class LastCompletedAndSuccessAndStableColumnDescriptor
-      extends AbstractCompactColumnDescriptor {
+  @Symbol("compactLastStableAndUnstable")
+  public static class DescriptorImpl extends AbstractCompactColumnDescriptor {
     @Override
     public String getDisplayName() {
       return Messages.Compact_Column_Unstable_Stable();

--- a/src/main/java/com/robestone/hudson/compactcolumns/LastSuccessAndFailedColumn.java
+++ b/src/main/java/com/robestone/hudson/compactcolumns/LastSuccessAndFailedColumn.java
@@ -24,6 +24,7 @@
 package com.robestone.hudson.compactcolumns;
 
 import hudson.Extension;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /** @author jacob robertson */
@@ -44,7 +45,8 @@ public class LastSuccessAndFailedColumn extends AbstractStatusesColumn {
   }
 
   @Extension
-  public static class LastSuccessAndFailedColumnDescriptor extends AbstractCompactColumnDescriptor {
+  @Symbol("compactLastSuccessAndFailed")
+  public static class DescriptorImpl extends AbstractCompactColumnDescriptor {
     @Override
     public String getDisplayName() {
       return Messages.Compact_Column_Stable_Failed();

--- a/src/test/java/com/robestone/hudson/compactcolumns/JobDSLTest.java
+++ b/src/test/java/com/robestone/hudson/compactcolumns/JobDSLTest.java
@@ -1,0 +1,65 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009, Sun Microsystems, Inc., Jesse Glick
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.robestone.hudson.compactcolumns;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import hudson.model.View;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Collections;
+import javaposse.jobdsl.dsl.DslScriptLoader;
+import javaposse.jobdsl.plugin.JenkinsJobManagement;
+import org.apache.commons.io.IOUtils;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class JobDSLTest {
+  @ClassRule public static JenkinsRule j = new JenkinsRule();
+
+  @Test
+  // This test makes sure that JobDSL scripts using automatically generated names work
+  public void testAutomaticJobDsl() throws IOException {
+    JenkinsJobManagement m =
+        new JenkinsJobManagement(System.out, Collections.emptyMap(), Paths.get(".").toFile());
+    new DslScriptLoader(m).runScript(readResource("/automaticJobDSL.groovy"));
+
+    View legacyView = j.jenkins.getView("legacyView");
+    assertThat(legacyView.getColumns(), iterableWithSize(5));
+    assertThat(
+        legacyView.getColumns(),
+        contains(
+            instanceOf(AllStatusesColumn.class),
+            instanceOf(JobNameColorColumn.class),
+            instanceOf(JobNameColumn.class),
+            instanceOf(LastStableAndUnstableColumn.class),
+            instanceOf(LastSuccessAndFailedColumn.class)));
+  }
+
+  private String readResource(String name) throws IOException {
+    return IOUtils.toString(JobDSLTest.class.getResourceAsStream(name));
+  }
+}

--- a/src/test/java/com/robestone/hudson/compactcolumns/JobDSLTest.java
+++ b/src/test/java/com/robestone/hudson/compactcolumns/JobDSLTest.java
@@ -43,11 +43,21 @@ public class JobDSLTest {
   @Test
   // This test makes sure that JobDSL scripts using automatically generated names work
   public void testAutomaticJobDsl() throws IOException {
+    doTest("automatic");
+  }
+
+  @Test
+  // This test makes sure that JobDSL scripts using symbol annotations work
+  public void testSymbolJobDsl() throws IOException {
+    doTest("symbol");
+  }
+
+  private void doTest(String type) throws IOException {
     JenkinsJobManagement m =
         new JenkinsJobManagement(System.out, Collections.emptyMap(), Paths.get(".").toFile());
-    new DslScriptLoader(m).runScript(readResource("/automaticJobDSL.groovy"));
+    new DslScriptLoader(m).runScript(readResource("/" + type + "JobDSL.groovy"));
 
-    View legacyView = j.jenkins.getView("legacyView");
+    View legacyView = j.jenkins.getView(type + "View");
     assertThat(legacyView.getColumns(), iterableWithSize(5));
     assertThat(
         legacyView.getColumns(),

--- a/src/test/resources/automaticJobDSL.groovy
+++ b/src/test/resources/automaticJobDSL.groovy
@@ -1,0 +1,19 @@
+listView('legacyView') {
+  columns {
+    allStatusesColumn {
+      colorblindHint 'underlinehint'
+      onlyShowLastStatus false
+      timeAgoTypeString 'PREFER_DATES'
+      hideDays 7
+    }
+    jobNameColorColumn {
+      showColor true
+      showDescription true
+      showLastBuild true
+      colorblindHint 'nohint'
+    }
+    jobNameColumn()
+    lastStableAndUnstableColumn()
+    lastSuccessAndFailedColumn()
+  }
+}

--- a/src/test/resources/symbolJobDSL.groovy
+++ b/src/test/resources/symbolJobDSL.groovy
@@ -1,19 +1,19 @@
-listView('automaticView') {
+listView('symbolView') {
   columns {
-    allStatusesColumn {
+    compactAllStatuses {
       colorblindHint 'underlinehint'
       onlyShowLastStatus false
       timeAgoTypeString 'PREFER_DATES'
       hideDays 7
     }
-    jobNameColorColumn {
+    compactJobNameColor {
       showColor true
       showDescription true
       showLastBuild true
       colorblindHint 'nohint'
     }
-    jobNameColumn()
-    lastStableAndUnstableColumn()
-    lastSuccessAndFailedColumn()
+    compactJobName()
+    compactLastStableAndUnstable()
+    compactLastSuccessAndFailed()
   }
 }


### PR DESCRIPTION
While this was primarily done for neater JobDSL configuration (and therefore contains test using that plugin), it should work the same for Configuration-as-Code. Using the new names makes it clear those columns are from this plugin and they cannot be confused with the default columns.