### PR TITLE
JENKINS-18622: Don't show "empty" tooltips

### DIFF
--- a/src/main/java/com/robestone/hudson/compactcolumns/JobNameColorColumn.java
+++ b/src/main/java/com/robestone/hudson/compactcolumns/JobNameColorColumn.java
@@ -104,7 +104,7 @@ public class JobNameColorColumn extends AbstractCompactColumn {
         }
       }
     }
-    return tip.toString();
+    return (tip.length() > 0) ? tip.toString() : null;
   }
 
   public boolean isShowColor() {

--- a/src/main/resources/com/robestone/hudson/compactcolumns/JobNameColumn/column.jelly
+++ b/src/main/resources/com/robestone/hudson/compactcolumns/JobNameColumn/column.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core">
   <td style="${indenter.getCss(job)}">
     <a href="${jobBaseUrl}${job.shortUrl}"
-        tooltip="${job.description}">
+        tooltip="${empty(job.description) ? null : job.description}">
       ${job.getRelativeDisplayNameFrom(itemGroup)}
     </a>
   </td>


### PR DESCRIPTION
It seems displaying tooltips with empty strings is problematic, so make
sure those aren't shown at all.