### PR TITLE
Update Jenkins baseline to 2.204

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,6 @@
-#!/usr/bin/env groovy
-
-/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin()
+#!groovy
+def recentLTS = "2.277.4"
+buildPlugin(configurations: [
+  [ platform: "linux", jdk: "8", jenkins: null ],
+  [ platform: "windows", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.57</version>
+    <version>4.18</version>
     <relativePath />
   </parent>
 
@@ -44,7 +44,7 @@
   <properties>
     <revision>1.13</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.121.3</jenkins.version>
+    <jenkins.version>2.204</jenkins.version>
     <java.level>8</java.level>
     <!-- TODO: Fix illegal accesses -->
     <access-modifier-checker.failOnError>false</access-modifier-checker.failOnError>
@@ -55,13 +55,13 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>symbol-annotation</artifactId>
-      <version>1.13</version>
+      <version>1.21</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>job-dsl</artifactId>
-      <version>1.72</version>
+      <version>1.77</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -84,7 +84,7 @@
       <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.9</version>
+        <version>2.9.1</version>
         <executions>
           <execution>
             <goals>

--- a/src/test/java/com/robestone/hudson/compactcolumns/JobDSLTest.java
+++ b/src/test/java/com/robestone/hudson/compactcolumns/JobDSLTest.java
@@ -24,10 +24,13 @@
 package com.robestone.hudson.compactcolumns;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.iterableWithSize;
 
 import hudson.model.View;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Collections;
 import javaposse.jobdsl.dsl.DslScriptLoader;
@@ -70,6 +73,6 @@ public class JobDSLTest {
   }
 
   private String readResource(String name) throws IOException {
-    return IOUtils.toString(JobDSLTest.class.getResourceAsStream(name));
+    return IOUtils.toString(JobDSLTest.class.getResourceAsStream(name), StandardCharsets.UTF_8);
   }
 }


### PR DESCRIPTION
Looking at http://stats.jenkins.io/pluginversions/compact-columns.html, this only affects less then 3% of plugin-updating users.