### PR TITLE
Switch to modern java.time API

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,4 +3,5 @@ def recentLTS = "2.277.4"
 buildPlugin(configurations: [
   [ platform: "linux", jdk: "8", jenkins: null ],
   [ platform: "windows", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],
+  [ platform: "linux", jdk: "11", jenkins: recentLTS, javaLevel: "8" ],
 ])


### PR DESCRIPTION
The intent was to just make a small change, but some differences in how the locale formats are different between Java 8 and 11 made this a little bit more involved...
