### PR TITLE
Update UI for newer versions of Jenkins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target/
 /work/
+.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -44,16 +44,22 @@
     <revision>1</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.350-rc32411.186041cf1c8b_</jenkins.version>
+    <jenkins.version>2.332</jenkins.version>
     <java.level>8</java.level>
     <doclint>all</doclint>
   </properties>
 
   <dependencies>
     <dependency>
+      <groupId>org.jenkins-ci</groupId>
+      <artifactId>symbol-annotation</artifactId>
+      <version>1.21</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>job-dsl</artifactId>
-      <version>1.77</version>
+      <version>1.79</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -44,18 +44,12 @@
     <revision>1</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.204</jenkins.version>
+    <jenkins.version>2.350-rc32411.186041cf1c8b_</jenkins.version>
     <java.level>8</java.level>
     <doclint>all</doclint>
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>org.jenkins-ci</groupId>
-      <artifactId>symbol-annotation</artifactId>
-      <version>1.21</version>
-      <scope>provided</scope>
-    </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>job-dsl</artifactId>

--- a/src/main/java/com/robestone/hudson/compactcolumns/AbstractStatusesColumn.java
+++ b/src/main/java/com/robestone/hudson/compactcolumns/AbstractStatusesColumn.java
@@ -436,19 +436,19 @@ public abstract class AbstractStatusesColumn extends AbstractCompactColumn {
     buf.append(build.getLatestBuildString(locale));
     buf.append("</u></b>\n");
     buf.append(
-        "<ul class=\"jenkins-!-margin-0 jenkins-!-margin-top-1 jenkins-!-padding-0\" style=\"list-style-position: inside\">\n");
+        "<ul class=\"jenkins-!-margin-0 jenkins-!-margin-top-1 jenkins-!-padding-0\" style=\"list-style-position: inside\">");
     buf.append("<li>");
     buf.append(build.getBuiltAt(locale));
-    buf.append("</li>\n");
+    buf.append("</li>");
     buf.append("<li>");
     buf.append(build.getStartedAgo(locale));
-    buf.append("</li>\n");
+    buf.append("</li>");
     buf.append("<li>");
     buf.append(build.getLastedDuration(locale));
-    buf.append("</li>\n");
+    buf.append("</li>");
     buf.append("<li><b>");
     buf.append(build.getStatus());
-    buf.append("</b></li>\n");
+    buf.append("</b></li>");
     buf.append("</ul>");
     return buf.toString();
   }

--- a/src/main/java/com/robestone/hudson/compactcolumns/AbstractStatusesColumn.java
+++ b/src/main/java/com/robestone/hudson/compactcolumns/AbstractStatusesColumn.java
@@ -104,7 +104,7 @@ public abstract class AbstractStatusesColumn extends AbstractCompactColumn {
       BuildInfo aborted =
           createBuildInfo(
               getLastAbortedBuild(job),
-              BuildInfo.OTHER_COLOR,
+              BuildInfo.getOtherColor(),
               OTHER_UNDERLINE_STYLE,
               getAbortedMessage(),
               null,
@@ -167,7 +167,7 @@ public abstract class AbstractStatusesColumn extends AbstractCompactColumn {
     } else if (!onlyIfLastCompleted || (lastCompletedBuild.number == lastFailedBuild.number)) {
       return createBuildInfo(
           job.getLastFailedBuild(),
-          BuildInfo.FAILED_COLOR,
+          BuildInfo.getFailedColor(),
           FAILED_UNDERLINE_STYLE,
           getFailedMessage(),
           "lastFailedBuild",
@@ -189,7 +189,7 @@ public abstract class AbstractStatusesColumn extends AbstractCompactColumn {
       TimeAgoType timeAgoType) {
     return createBuildInfo(
         job.getLastStableBuild(),
-        BuildInfo.getStableColorString(),
+        BuildInfo.getStableColor(),
         STABLE_UNDERLINE_STYLE,
         getStableMessage(),
         "lastStableBuild",
@@ -221,7 +221,7 @@ public abstract class AbstractStatusesColumn extends AbstractCompactColumn {
 
     return createBuildInfo(
         lastUnstable,
-        BuildInfo.UNSTABLE_COLOR,
+        BuildInfo.getUnstableColor(),
         UNSTABLE_UNDERLINE_STYLE,
         getUnstableMessage(),
         String.valueOf(lastUnstable.number),
@@ -435,7 +435,8 @@ public abstract class AbstractStatusesColumn extends AbstractCompactColumn {
     buf.append(build.getRun().number);
     buf.append(build.getLatestBuildString(locale));
     buf.append("</u></b>\n");
-    buf.append("<ul>\n");
+    buf.append(
+        "<ul class=\"jenkins-!-margin-0 jenkins-!-margin-top-1 jenkins-!-padding-0\" style=\"list-style-position: inside\">\n");
     buf.append("<li>");
     buf.append(build.getBuiltAt(locale));
     buf.append("</li>\n");

--- a/src/main/java/com/robestone/hudson/compactcolumns/BuildInfo.java
+++ b/src/main/java/com/robestone/hudson/compactcolumns/BuildInfo.java
@@ -1,23 +1,16 @@
 package com.robestone.hudson.compactcolumns;
 
 import hudson.model.Run;
-import hudson.util.ColorPalette;
-import java.awt.Color;
 import java.util.Locale;
 import java.util.Objects;
 
 /** @author jacob robertson */
 public class BuildInfo implements Comparable<BuildInfo> {
 
-  /** Orange is yellowish, and shows up better on the webpage. */
-  public static final String UNSTABLE_COLOR = toColorString(new Color(255, 165, 0));
-
-  private static String STABLE_COLOR;
-  public static final String OTHER_COLOR = toColorString(ColorPalette.GREY);
-  public static final String FAILED_COLOR = toColorString(ColorPalette.RED);
-
-  /** Work-around to check whether the palette has been changed. */
-  private static final Color BLUE_FROM_PALETTE = new Color(0x72, 0x9F, 0xCF);
+  private static final String STABLE_COLOR = "var(--success-color, green)";
+  private static final String UNSTABLE_COLOR = "var(--warning-color, orange)";
+  private static final String FAILED_COLOR = "var(--error-color, red)";
+  private static final String OTHER_COLOR = "var(--text-color-secondary, grey)";
 
   private final Run<?, ?> run;
   private String color;
@@ -47,45 +40,20 @@ public class BuildInfo implements Comparable<BuildInfo> {
     this.isLatestBuild = isLatestBuild;
   }
 
-  public static String getUnstableColorString() {
-    return UNSTABLE_COLOR;
-  }
-
-  public static String getFailedColorString() {
-    return FAILED_COLOR;
-  }
-
-  public static String getStableColorString() {
-    if (STABLE_COLOR == null) {
-      STABLE_COLOR = toColorString(getStableColor());
-    }
+  public static String getStableColor() {
     return STABLE_COLOR;
   }
 
-  static Color getStableColor() {
-    // determine whether to use the Jenkins palette or our own
-    boolean isPaletteStandard = BLUE_FROM_PALETTE.equals(ColorPalette.BLUE);
-    if (isPaletteStandard) {
-      // we don't like the standard palette for blue, so we return a "better blue"
-      return Color.BLUE;
-    } else {
-      // since someone has changed the palette under the covers, we will honor that
-      return ColorPalette.BLUE;
-    }
+  public static String getUnstableColor() {
+    return UNSTABLE_COLOR;
   }
 
-  static String toColorString(Color color) {
-    StringBuilder buf = new StringBuilder("#");
-    try {
-      String hex = Integer.toHexString(color.getRGB() & 0x00ffffff);
-      String zeroes = "000000";
-      int len = zeroes.length() - hex.length();
-      buf.append(zeroes.substring(0, len));
-      buf.append(hex);
-    } catch (Throwable t) {
-      buf.append(t.getMessage());
-    }
-    return buf.toString();
+  public static String getFailedColor() {
+    return FAILED_COLOR;
+  }
+
+  public static String getOtherColor() {
+    return OTHER_COLOR;
   }
 
   public Run<?, ?> getRun() {

--- a/src/main/java/com/robestone/hudson/compactcolumns/BuildInfo.java
+++ b/src/main/java/com/robestone/hudson/compactcolumns/BuildInfo.java
@@ -7,10 +7,10 @@ import java.util.Objects;
 /** @author jacob robertson */
 public class BuildInfo implements Comparable<BuildInfo> {
 
-  private static final String STABLE_COLOR = "var(--success-color, green)";
-  private static final String UNSTABLE_COLOR = "var(--warning-color, orange)";
-  private static final String FAILED_COLOR = "var(--error-color, red)";
-  private static final String OTHER_COLOR = "var(--text-color-secondary, grey)";
+  private static final String STABLE_COLOR = "var(--success-color, green) !important";
+  private static final String UNSTABLE_COLOR = "var(--warning-color, orange) !important";
+  private static final String FAILED_COLOR = "var(--error-color, red) !important";
+  private static final String OTHER_COLOR = "var(--text-color-secondary, grey) !important";
 
   private final Run<?, ?> run;
   private String color;

--- a/src/main/java/com/robestone/hudson/compactcolumns/JobNameColorColumn.java
+++ b/src/main/java/com/robestone/hudson/compactcolumns/JobNameColorColumn.java
@@ -42,25 +42,25 @@ public class JobNameColorColumn extends AbstractCompactColumn {
     String color;
     String underline;
     if (result == null) {
-      color = BuildInfo.OTHER_COLOR;
+      color = BuildInfo.getOtherColor();
       underline = AbstractStatusesColumn.OTHER_UNDERLINE_STYLE;
     } else if (Result.ABORTED.equals(result)) {
-      color = BuildInfo.OTHER_COLOR;
+      color = BuildInfo.getOtherColor();
       underline = AbstractStatusesColumn.OTHER_UNDERLINE_STYLE;
     } else if (Result.FAILURE.equals(result)) {
-      color = BuildInfo.FAILED_COLOR;
+      color = BuildInfo.getFailedColor();
       underline = AbstractStatusesColumn.FAILED_UNDERLINE_STYLE;
     } else if (Result.NOT_BUILT.equals(result)) {
-      color = BuildInfo.OTHER_COLOR;
+      color = BuildInfo.getOtherColor();
       underline = AbstractStatusesColumn.OTHER_UNDERLINE_STYLE;
     } else if (Result.SUCCESS.equals(result)) {
-      color = BuildInfo.getStableColorString();
+      color = BuildInfo.getStableColor();
       underline = AbstractStatusesColumn.STABLE_UNDERLINE_STYLE;
     } else if (Result.UNSTABLE.equals(result)) {
-      color = BuildInfo.UNSTABLE_COLOR;
+      color = BuildInfo.getUnstableColor();
       underline = AbstractStatusesColumn.UNSTABLE_UNDERLINE_STYLE;
     } else {
-      color = BuildInfo.OTHER_COLOR;
+      color = BuildInfo.getOtherColor();
       underline = AbstractStatusesColumn.OTHER_UNDERLINE_STYLE;
     }
     String style = "";

--- a/src/main/resources/com/robestone/hudson/compactcolumns/AbstractStatusesColumn/column.jelly
+++ b/src/main/resources/com/robestone/hudson/compactcolumns/AbstractStatusesColumn/column.jelly
@@ -7,9 +7,9 @@
           <j:if test="${!build.first}">
             <st:nbsp />&gt;<st:nbsp />
           </j:if>
-          <a href="${jobBaseUrl}${job.shortUrl}${build.urlPart}"
+          <a href="${jobBaseUrl}${job.shortUrl}${build.urlPart}" class="jenkins-table__link"
               style="color: ${build.color}; font-weight: ${build.fontWeight}; text-decoration: ${build.textDecoration}; border-bottom: ${build.underlineStyle}"
-              tooltip="${it.getToolTip(build, request.locale)}">
+             tooltip="${it.getToolTip(build, request.locale)}" html-tooltip="${it.getToolTip(build, request.locale)}">
             ${build.timeAgoString}
           </a>
         </j:forEach>

--- a/src/main/resources/com/robestone/hudson/compactcolumns/AbstractStatusesColumn/columnHeader.jelly
+++ b/src/main/resources/com/robestone/hudson/compactcolumns/AbstractStatusesColumn/columnHeader.jelly
@@ -9,14 +9,20 @@
       method="getStableMessage" />
 
   <j:invokeStatic var="color_stable" className="com.robestone.hudson.compactcolumns.BuildInfo"
-      method="getStableColorString" />
+      method="getStableColor" />
   <j:invokeStatic var="color_unstable" className="com.robestone.hudson.compactcolumns.BuildInfo"
-      method="getUnstableColorString" />
+      method="getUnstableColor" />
   <j:invokeStatic var="color_failed" className="com.robestone.hudson.compactcolumns.BuildInfo"
-      method="getFailedColorString" />
+      method="getFailedColor" />
 
   <th tooltip=
       "&lt;span style='text-decoration: underline; color: ${color_failed}'&gt;${message_failed}&lt;/span&gt;;
+     &lt;span style='text-decoration: underline; color: ${color_unstable}'&gt;${message_unstable}&lt;/span&gt;;
+     &lt;span style='text-decoration: underline; color: ${color_stable}'&gt;${message_stable}&lt;/span&gt;
+    &lt;br/&gt;
+	&lt;b&gt;${%More Recent}&lt;/b&gt; &gt; ${%Less Recent}"
+      html-tooltip=
+              "&lt;span style='text-decoration: underline; color: ${color_failed}'&gt;${message_failed}&lt;/span&gt;;
      &lt;span style='text-decoration: underline; color: ${color_unstable}'&gt;${message_unstable}&lt;/span&gt;;
      &lt;span style='text-decoration: underline; color: ${color_stable}'&gt;${message_stable}&lt;/span&gt;
     &lt;br/&gt;

--- a/src/main/resources/com/robestone/hudson/compactcolumns/AbstractStatusesColumn/columnHeader.jelly
+++ b/src/main/resources/com/robestone/hudson/compactcolumns/AbstractStatusesColumn/columnHeader.jelly
@@ -15,18 +15,17 @@
   <j:invokeStatic var="color_failed" className="com.robestone.hudson.compactcolumns.BuildInfo"
       method="getFailedColor" />
 
-  <th tooltip=
-      "&lt;span style='text-decoration: underline; color: ${color_failed}'&gt;${message_failed}&lt;/span&gt;;
-     &lt;span style='text-decoration: underline; color: ${color_unstable}'&gt;${message_unstable}&lt;/span&gt;;
-     &lt;span style='text-decoration: underline; color: ${color_stable}'&gt;${message_stable}&lt;/span&gt;
-    &lt;br/&gt;
-	&lt;b&gt;${%More Recent}&lt;/b&gt; &gt; ${%Less Recent}"
-      html-tooltip=
-              "&lt;span style='text-decoration: underline; color: ${color_failed}'&gt;${message_failed}&lt;/span&gt;;
-     &lt;span style='text-decoration: underline; color: ${color_unstable}'&gt;${message_unstable}&lt;/span&gt;;
-     &lt;span style='text-decoration: underline; color: ${color_stable}'&gt;${message_stable}&lt;/span&gt;
-    &lt;br/&gt;
-	&lt;b&gt;${%More Recent}&lt;/b&gt; &gt; ${%Less Recent}">
+  <j:set var="tooltip">
+    <div style="display: flex;">
+      <span style='text-decoration: underline; color: ${color_failed}'>${message_failed}</span>
+      <span class="jenkins-!-margin-right-1">;</span>
+      <span style='text-decoration: underline; color: ${color_unstable}'>${message_unstable}</span>
+      <span class="jenkins-!-margin-right-1">;</span>
+      <span style='text-decoration: underline; color: ${color_stable}'>${message_stable}</span>
+    </div>
+    <div class="jenkins-!-margin-top-1"><b>${%More Recent}</b> > ${%Less Recent}</div>
+  </j:set>
+  <th tooltip="${tooltip}" html-tooltip="${tooltip}">
     ${%Last Statuses}
   </th>
 </j:jelly>

--- a/src/main/resources/com/robestone/hudson/compactcolumns/JobNameColorColumn/column.jelly
+++ b/src/main/resources/com/robestone/hudson/compactcolumns/JobNameColorColumn/column.jelly
@@ -2,7 +2,9 @@
 <j:jelly xmlns:j="jelly:core">
   <td style="${indenter.getCss(job)}">
     <a href="${jobBaseUrl}${job.shortUrl}"
+        class="jenkins-table__link"
         tooltip="${it.getToolTip(job, request.locale)}"
+        html-tooltip="${it.getToolTip(job, request.locale)}"
         style="${it.getStyle(job)}">
       ${job.getRelativeDisplayNameFrom(itemGroup)}
     </a>

--- a/src/main/resources/com/robestone/hudson/compactcolumns/JobNameColumn/column.jelly
+++ b/src/main/resources/com/robestone/hudson/compactcolumns/JobNameColumn/column.jelly
@@ -2,7 +2,10 @@
 <j:jelly xmlns:j="jelly:core">
   <td style="${indenter.getCss(job)}">
     <a href="${jobBaseUrl}${job.shortUrl}"
+       class="jenkins-table__link"
         tooltip="${empty(job.description) ? null :
+         app.markupFormatter.translate(job.description)}"
+       html-tooltip="${empty(job.description) ? null :
          app.markupFormatter.translate(job.description)}">
       ${job.getRelativeDisplayNameFrom(itemGroup)}
     </a>

--- a/src/test/java/com/robestone/hudson/compactcolumns/CompactColumnsPresentationTest.java
+++ b/src/test/java/com/robestone/hudson/compactcolumns/CompactColumnsPresentationTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 import com.gargoylesoftware.htmlunit.html.DomElement;
+import com.gargoylesoftware.htmlunit.html.DomNode;
 import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.model.FreeStyleProject;
@@ -38,7 +39,8 @@ public class CompactColumnsPresentationTest {
     JenkinsRule.WebClient wc = j.createWebClient();
     HtmlPage page = wc.goTo("view/testView/");
     DomElement table = page.getElementById("projectstatus");
-    for (DomElement row : table.getElementsByTagName("tr")) {
+    for (DomNode node : table.querySelectorAll("tbody tr")) {
+      DomElement row = (DomElement) node;
       if (!row.getAttribute("class").contains("header")) {
         validateRow(row);
       }

--- a/src/test/java/com/robestone/hudson/compactcolumns/CompactColumnsTest.java
+++ b/src/test/java/com/robestone/hudson/compactcolumns/CompactColumnsTest.java
@@ -264,22 +264,22 @@ public class CompactColumnsTest {
 
   @Test
   public void testStableColor() throws Exception {
-    assertEquals(Color.BLUE, BuildInfo.getStableColor());
-    assertFalse(ColorPalette.BLUE.equals(BuildInfo.getStableColor()));
+    //    assertEquals(Color.BLUE, BuildInfo.getStableColor());
+    //    assertFalse(ColorPalette.BLUE.equals(BuildInfo.getStableColor()));
 
     Field colorValue = Color.class.getDeclaredField("value");
     colorValue.setAccessible(true);
     colorValue.setInt(ColorPalette.BLUE, new Color(172, 218, 0).getRGB());
 
-    assertEquals(ColorPalette.BLUE, BuildInfo.getStableColor());
-    assertFalse(Color.BLUE.equals(BuildInfo.getStableColor()));
+    //    assertEquals(ColorPalette.BLUE, BuildInfo.getStableColor());
+    //    assertFalse(Color.BLUE.equals(BuildInfo.getStableColor()));
   }
 
   @Test
   public void testColorString() {
-    assertEquals("#0000ff", BuildInfo.getStableColorString());
+    //    assertEquals("#0000ff", BuildInfo.getStableColorString());
     assertEquals("#ef2929", BuildInfo.FAILED_COLOR);
-    assertEquals("#000303", BuildInfo.toColorString(new Color(0, 3, 3)));
+    //    assertEquals("#000303", BuildInfo.toColorString(new Color(0, 3, 3)));
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})

--- a/src/test/java/com/robestone/hudson/compactcolumns/CompactColumnsTest.java
+++ b/src/test/java/com/robestone/hudson/compactcolumns/CompactColumnsTest.java
@@ -35,9 +35,6 @@ import com.robestone.hudson.compactcolumns.AbstractStatusesColumn.TimeAgoType;
 import hudson.model.Job;
 import hudson.model.Result;
 import hudson.model.Run;
-import hudson.util.ColorPalette;
-import java.awt.Color;
-import java.lang.reflect.Field;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -260,26 +257,6 @@ public class CompactColumnsTest {
           break;
       }
     }
-  }
-
-  @Test
-  public void testStableColor() throws Exception {
-    //    assertEquals(Color.BLUE, BuildInfo.getStableColor());
-    //    assertFalse(ColorPalette.BLUE.equals(BuildInfo.getStableColor()));
-
-    Field colorValue = Color.class.getDeclaredField("value");
-    colorValue.setAccessible(true);
-    colorValue.setInt(ColorPalette.BLUE, new Color(172, 218, 0).getRGB());
-
-    //    assertEquals(ColorPalette.BLUE, BuildInfo.getStableColor());
-    //    assertFalse(Color.BLUE.equals(BuildInfo.getStableColor()));
-  }
-
-  @Test
-  public void testColorString() {
-    //    assertEquals("#0000ff", BuildInfo.getStableColorString());
-    assertEquals("#ef2929", BuildInfo.FAILED_COLOR);
-    //    assertEquals("#000303", BuildInfo.toColorString(new Color(0, 3, 3)));
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})


### PR DESCRIPTION
The way tooltips work are implemented in Jenkins is changing as part of https://github.com/jenkinsci/jenkins/pull/6408, this PR updates this plugin to work with the new tooltips and also updates the color scheme for the plugin to meet the new semantic colors in newer versions of Jenkins.

**2.332**
<img width="1058" alt="image" src="https://user-images.githubusercontent.com/43062514/171235252-ffb212d4-a87a-4b94-b7f6-f3401a3eff2e.png">

<img width="307" alt="image" src="https://user-images.githubusercontent.com/43062514/171235338-8f36ba47-3406-48aa-87e9-0f1e097b5cee.png">

**[Jenkins with new tooltips](https://github.com/jenkinsci/jenkins/pull/6408) and above**
<img width="1065" alt="image" src="https://user-images.githubusercontent.com/43062514/171235769-b6a605f8-7872-4aa7-9fda-255b5482eb58.png">

<img width="249" alt="image" src="https://user-images.githubusercontent.com/43062514/171235798-dceea6bb-c631-4d01-8c52-40e23138f61d.png">

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
