### PR TITLE
Fix tooltip attribute for newer Jenkins versions

### DIFF
--- a/src/main/resources/com/robestone/hudson/compactcolumns/AbstractStatusesColumn/column.jelly
+++ b/src/main/resources/com/robestone/hudson/compactcolumns/AbstractStatusesColumn/column.jelly
@@ -9,7 +9,7 @@
           </j:if>
           <a href="${jobBaseUrl}${job.shortUrl}${build.urlPart}" class="jenkins-table__link"
               style="color: ${build.color}; font-weight: ${build.fontWeight}; text-decoration: ${build.textDecoration}; border-bottom: ${build.underlineStyle}"
-             tooltip="${it.getToolTip(build, request.locale)}" html-tooltip="${it.getToolTip(build, request.locale)}">
+             tooltip="${it.getToolTip(build, request.locale)}" data-html-tooltip="${it.getToolTip(build, request.locale)}">
             ${build.timeAgoString}
           </a>
         </j:forEach>

--- a/src/main/resources/com/robestone/hudson/compactcolumns/AbstractStatusesColumn/columnHeader.jelly
+++ b/src/main/resources/com/robestone/hudson/compactcolumns/AbstractStatusesColumn/columnHeader.jelly
@@ -25,7 +25,7 @@
     </div>
     <div class="jenkins-!-margin-top-1"><b>${%More Recent}</b> > ${%Less Recent}</div>
   </j:set>
-  <th tooltip="${tooltip}" html-tooltip="${tooltip}">
+  <th tooltip="${tooltip}" data-html-tooltip="${tooltip}">
     ${%Last Statuses}
   </th>
 </j:jelly>

--- a/src/main/resources/com/robestone/hudson/compactcolumns/JobNameColorColumn/column.jelly
+++ b/src/main/resources/com/robestone/hudson/compactcolumns/JobNameColorColumn/column.jelly
@@ -4,7 +4,7 @@
     <a href="${jobBaseUrl}${job.shortUrl}"
         class="jenkins-table__link"
         tooltip="${it.getToolTip(job, request.locale)}"
-        html-tooltip="${it.getToolTip(job, request.locale)}"
+        data-html-tooltip="${it.getToolTip(job, request.locale)}"
         style="${it.getStyle(job)}">
       ${job.getRelativeDisplayNameFrom(itemGroup)}
     </a>

--- a/src/main/resources/com/robestone/hudson/compactcolumns/JobNameColumn/column.jelly
+++ b/src/main/resources/com/robestone/hudson/compactcolumns/JobNameColumn/column.jelly
@@ -5,7 +5,7 @@
        class="jenkins-table__link"
         tooltip="${empty(job.description) ? null :
          app.markupFormatter.translate(job.description)}"
-       html-tooltip="${empty(job.description) ? null :
+       data-html-tooltip="${empty(job.description) ? null :
          app.markupFormatter.translate(job.description)}">
       ${job.getRelativeDisplayNameFrom(itemGroup)}
     </a>


### PR DESCRIPTION
This amends #52 since the HTML tooltip attribute was changed before the Jenkins core change was merged...